### PR TITLE
doc: update algolia docsearch logic

### DIFF
--- a/docs/static/css/algolia.css
+++ b/docs/static/css/algolia.css
@@ -1,11 +1,5 @@
 /* --- Algolia Docsearch Styles --- */
 
-/* Some sphinx ajustment */
-/* https://github.com/readthedocs/sphinx_rtd_theme/issues/761 */
-.wy-nav-side {
-    overflow: visible;
-}
-
 /* Override sphinx theme styles for search box */
 .DocSearch-Input {
     border: none !important;

--- a/docs/static/js/algolia.js
+++ b/docs/static/js/algolia.js
@@ -74,10 +74,15 @@ if (typeof READTHEDOCS_DATA !== 'undefined') {
 // Set translations
 if (language.startsWith("zh")) {
   config.translations = algolia_i18n;
-  config.indexName = 'mcdreforgeddocs-zh_CN';
+  config.searchParameters = {
+    facetFilters: [`lang:zh-CN`]
+  };
   config.placeholder = algolia_i18n.placeholder;
   switchgear_tr = switchgear_i18n.zh;
 } else {
+  config.searchParameters = {
+    facetFilters: [`lang:en`]
+  };
   switchgear_tr = switchgear_i18n.en;
 }
 


### PR DESCRIPTION
update Docsearch logic since the logic change of Algolia Crawler, to avoid confusing results.
![image](https://github.com/user-attachments/assets/1cb9f2c3-e3ac-41a5-9d71-3608a4b7818b)
