### PR TITLE
fixed environment_check

### DIFF
--- a/mcdreforged/mcdr_entrypoint.py
+++ b/mcdreforged/mcdr_entrypoint.py
@@ -12,7 +12,7 @@ def __environment_check():
 	"""
 	This should even work in python 2.7+
 	"""
-	if sys.version_info < (3,8):
+	if sys.version_info < (3, 8):
 		print('Python 3.8+ is needed to run {}'.format(core_constant.NAME))
 		print('Current Python version {} is too old'.format(platform.python_version()))
 		sys.exit(1)

--- a/mcdreforged/mcdr_entrypoint.py
+++ b/mcdreforged/mcdr_entrypoint.py
@@ -12,8 +12,7 @@ def __environment_check():
 	"""
 	This should even work in python 2.7+
 	"""
-	python_version = sys.version_info.major + sys.version_info.minor * 0.1
-	if python_version < 3.8:
+	if sys.version_info < (3,8):
 		print('Python 3.8+ is needed to run {}'.format(core_constant.NAME))
 		print('Current Python version {} is too old'.format(platform.python_version()))
 		sys.exit(1)


### PR DESCRIPTION
原代码在进行版本比较时使用浮点数比较，但是这可能会在处理后续版本时带来不可预测的问题
如：python 3.10 在原逻辑下会被转换为 4 与 3.8 进行比较，这在目前虽然可以正确运行但仍存在潜在风险