### PR TITLE
[Bug Fix] fix error when removing unexpected keys without default_config

### DIFF
--- a/mcdreforged/plugin/si/plugin_server_interface.py
+++ b/mcdreforged/plugin/si/plugin_server_interface.py
@@ -379,11 +379,11 @@ class PluginServerInterface(ServerInterface):
 							result_config[key] = value
 							log(self._tr('load_config_simple.key_missed', key, value))
 							needs_save = True
-
-				# remove unexpected keys
-				for key in list(result_config.keys()):
-					if key not in default_config:
-						result_config.pop(key)
+	
+					# remove unexpected keys
+					for key in list(result_config.keys()):
+						if key not in default_config:
+							result_config.pop(key)
 
 		log(self._tr('load_config_simple.succeed'))
 		if needs_save:


### PR DESCRIPTION
MCDR版本：2.14.3

在调试插件使用`load_config_simple`时报错：
```
  File "C:\...\Python\Python311\site-packages\mcdreforged\plugin\si\plugin_server_interface.py", line 385, in load_config_simple
    if key not in default_config:
       ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```
但实际上，我在调用时仅仅使用了`server.load_config_simple()`，并未传入`default_config`

在翻阅MCDR-2.11版本的源码时，在该函数中有：
```python
			if default_config is not None:
				for key in list(result_config.keys()):
					if key not in default_config:
						result_config.pop(key)
```
当我将本地MCDR版本回退到2.11.0时，该报错消失了

但是在最新版本的MCDR中，该函数这一部分被放在了`if default_config is not None`外：
```python
				if default_config is not None:
					# Notes: support level-1 nesting only
					# constructing the result config based on the given default config
					for key, value in default_config.items():
						if key not in read_data:
							result_config[key] = value
							log(self._tr('load_config_simple.key_missed', key, value))
							needs_save = True

				# remove unexpected keys
				for key in list(result_config.keys()):
					if key not in default_config:
						result_config.pop(key)
```

我尝试将# remove unexpected keys部分的代码增加缩进至`if default_config is not None`中，bug得到修复，报错消失