### PR TITLE
feat: use block style for YAML configs

### DIFF
--- a/mcdreforged/plugin/si/_simple_config_handler.py
+++ b/mcdreforged/plugin/si/_simple_config_handler.py
@@ -33,6 +33,7 @@ class SimpleConfigHandler:
 			dumper = functools.partial(json.dump, indent=4, ensure_ascii=False)
 		elif file_format == 'yaml':
 			yaml = YAML(typ='safe')
+			yaml.default_flow_style = False  # use block style for yaml
 			yaml.width = 1048576
 			dumper = yaml.dump
 			loader = yaml.load


### PR DESCRIPTION
Seems `YAML(typ='safe')` uses flow style by default while `YAML()` don't.
I didn't find a doc for this though

```python
>>> from ruamel.yaml import YAML
>>> import sys

>>> yaml = YAML()
>>> yaml.dump({'a': [1, 2], 'b': {'c': 'd'}}, sys.stdout)
a:
- 1
- 2
b:
  c: d

>>> yaml = YAML(typ='safe')
>>> yaml.dump({'a': [1, 2], 'b': {'c': 'd'}}, sys.stdout)
a: [1, 2]
b: {c: d}

>>> yaml = YAML(typ='safe')
>>> yaml.default_flow_style = False
>>> yaml.dump({'a': [1, 2], 'b': {'c': 'd'}}, sys.stdout)
a:
- 1
- 2
b:
  c: d
```