### PR TITLE
fix(docs): wrong statement of extension `sphinx_prompt`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ extensions = [
 	'sphinx.ext.napoleon',
 	'sphinx.ext.viewcode',
 	'sphinx_copybutton',
-	'sphinx-prompt',
+	'sphinx_prompt',
 
 	# workaround for broken search utility and broken doc version popup
 	# https://github.com/readthedocs/sphinx_rtd_theme/issues/1451


### PR DESCRIPTION
## Problem

https://app.readthedocs.org/projects/mcdreforged/builds/28678810/

## Reproduce

```batch
cd docs/
make html
```

## Ref

https://github.com/sbrunner/sphinx-prompt?tab=readme-ov-file#initialize