### PR TITLE
给log添加文件锁以避免多个MCDR实例在同一目录下运行

### DIFF
--- a/mcdreforged/mcdr_server.py
+++ b/mcdreforged/mcdr_server.py
@@ -8,6 +8,7 @@ from importlib.metadata import PackageNotFoundError, Distribution
 from pathlib import Path
 from typing import Optional, Callable, Any, TYPE_CHECKING, List, Dict, Union
 
+import filelock
 from ruamel.yaml import YAMLError
 
 from mcdreforged.command.command_manager import CommandManager
@@ -156,7 +157,15 @@ class MCDReforgedServer:
 			return
 
 		# MCDR environment has been set up, so continue creating default folders and loading stuffs
-		self.logger.set_file(core_constant.LOGGING_FILE)  # will create logs/ folder
+
+		try:
+			self.logger.set_file(core_constant.LOGGING_FILE)  # will create logs/ folder
+		except filelock.Timeout:
+			self.logger.error("Could not acquire lock for logfile: \"{}\".".format(core_constant.LOGGING_FILE+".lock"))
+			self.logger.error("This usually means another MCDR instance is logging to the same folder.")
+			self.logger.error("Please stop those instances to remove the lock.")
+			return
+
 		self.plugin_manager.touch_directory()  # will create config/ folder
 
 		# --- Done --- #

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ resolvelib
 ruamel.yaml~=0.17,<0.19
 typing-extensions>=4.6.0
 wcwidth
+filelock


### PR DESCRIPTION
在Linux环境下，文件读写是非独占的，这导致多个MCDR实例同时在一个目录中运行时并不会像Windows环境中一样正确的报错“log文件被占用”并退出，而是会继续运行，弄乱log文件的内容并继续运行直到游戏或MCDR的其他部分报错为止，对使用调试造成了不便。

这个commit使用filelock库为log添加了具有跨平台支持的文件锁，在linux-x64下测试正常，修复了这个问题。