### PR TITLE
Add delay after sending RCON packets

### DIFF
--- a/mcdreforged/minecraft/rcon/rcon_connection.py
+++ b/mcdreforged/minecraft/rcon/rcon_connection.py
@@ -8,6 +8,7 @@ import os
 import socket
 import struct
 import sys
+import time
 from logging import Logger
 from threading import RLock
 from typing import Optional, List, ClassVar
@@ -80,6 +81,9 @@ class RconConnection:
 	def __send(self, data: Packet):
 		assert self.socket is not None
 		self.socket.sendall(data.dump_with_length_header())
+		# MC-72390: some server implementations can break if packets are sent too fast
+		# (especially when sending command request + ending packet back-to-back).
+		time.sleep(0.03)
 
 	def __receive(self, length: int) -> bytes:
 		assert self.socket is not None


### PR DESCRIPTION
~~更改项：为 RCON 连续发包增加 0.03s 延迟~~
### 更新方案已由Fallen接管

## 背景 / 发生了什么

关联 #407。经测试，在 `MCDReforged >= 2.15.5` 环境下，对多个版本服务端实现 **发送RCON请求** 时均可稳定复现以下告警：

`Rcon fail to receive packet: Connection closed by peer while reading data, expect 4, read 0`

并造成 **命令执行失败 / 结果返回失败**

## 原因分析

根据当前 RCON 实现，MCDR 在一次 `send_command` 中会连续发送 **两次请求**（命令请求包 + 结束探测包）以确定响应结束。

两包发送间隔过短时(`<30ms`)，**且服务端存在功能薄弱问题**，主动断开连接，从而导致上述告警，并触发 `MCDR 侧` 与 `服务端侧` 重连

参考：[MC-87863](https://bugs.mojang.com/browse/MC/issues/MC-87863)

## 变更内容

### 注意：此更改方案已过时

> 在每次 RCON `sendall` 后增加 `time.sleep(0.03)`
> 
> 为服务端留出处理窗口，避免 **快速发包** 触发断连

## 测试结果

应用该变更后，测试环境中服务端不再出现 RCON 客户端连接被断开的现象，上述告警不再复现
