### PR TITLE
Typo

### DIFF
--- a/docs/source/_locale/zh_CN/LC_MESSAGES/code_references/minecraft_tools.po
+++ b/docs/source/_locale/zh_CN/LC_MESSAGES/code_references/minecraft_tools.po
@@ -953,7 +953,7 @@ msgstr "操作的最大重试次数"
 
 #: mcdreforged.minecraft.rcon.rcon_connection.RconConnection.send_command:5 of
 msgid ""
-"The command execution result form the server, or None if *max_retry_time*"
+"The command execution result from the server, or None if *max_retry_time*"
 " retries exceeded"
 msgstr "服务器的命令执行结果。如果重试次数超过 *max_retry_time*，则将返回 None"
 


### PR DESCRIPTION
文档[这里](https://docs.mcdreforged.com/zh-cn/latest/code_references/minecraft_tools.html#mcdreforged.minecraft.rcon.rcon_connection.RconConnection.send_command)最后的返回值没有翻译，我简单修了一下

and 发现了一处漏字